### PR TITLE
Fixed slight flicker in header/footer elements on slide animation on Android phones

### DIFF
--- a/src/android/NativePageTransitions.java
+++ b/src/android/NativePageTransitions.java
@@ -503,7 +503,7 @@ public class NativePageTransitions extends CordovaPlugin {
               webViewAnimation.addAnimation(webViewAnimation2);
             }
 
-            imageViewAnimation.setAnimationListener(new Animation.AnimationListener() {
+            webViewAnimation.setAnimationListener(new Animation.AnimationListener() {
               @Override
               public void onAnimationStart(Animation animation) {
               }


### PR DESCRIPTION
Changed which animation object will trigger the removal of the fixed header & footer images in the slide transition. This fixes an issue where the header and footer images appeared to flicker slightly with small animation durations - it appears they were being removed one frame too soon. 