### PR TITLE
fixes fade transition screenshot for iOS WkWebView (issue #109 )

### DIFF
--- a/src/ios/NativePageTransitions.m
+++ b/src/ios/NativePageTransitions.m
@@ -590,7 +590,11 @@
   CGSize viewSize = self.viewController.view.bounds.size;
 
     UIGraphicsBeginImageContextWithOptions(viewSize, YES, 0.0f);
-  [self.viewController.view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    if (self.wkWebView != nil) {
+        [self.viewController.view drawViewHierarchyInRect:self.viewController.view.bounds afterScreenUpdates:NO];
+    } else {
+        [self.viewController.view.layer renderInContext:UIGraphicsGetCurrentContext()];
+    }
 
   // Read the UIImage object
   UIImage *image = UIGraphicsGetImageFromCurrentImageContext();


### PR DESCRIPTION
it looks like the screenshot for the fade transition was turning out white on iOS when WkWebView was installed

this PR modifies the screenshot for the fade transition to use the same WkWebView sensitive method as the slide transition already does

fixes #109 and makes the fade transition work with the WkWebView



