### PR TITLE
Remove unnecessary .html filter

### DIFF
--- a/src/android/NativePageTransitions.java
+++ b/src/android/NativePageTransitions.java
@@ -196,7 +196,7 @@ public class NativePageTransitions extends CordovaPlugin {
           }
 
           if (href != null && !"null".equals(href)) {
-            if (!href.startsWith("#") && href.contains(".html")) {
+            if (!href.startsWith("#")) {
               webView.loadUrlIntoView(webView.getUrl().substring(0, webView.getUrl().lastIndexOf('/')+1) + href, false);
             }
           }

--- a/src/ios/NativePageTransitions.m
+++ b/src/ios/NativePageTransitions.m
@@ -723,7 +723,7 @@
     uiwebview = ((UIWebView*)self.webView);
   }
   if (href != nil && ![href isEqual:[NSNull null]]) {
-    if (![href hasPrefix:@"#"] && [href rangeOfString:@".html"].location != NSNotFound) {
+    if (![href hasPrefix:@"#"]) {
       // strip any params when looking for the file on the filesystem
       NSString *bareFileName = href;
       NSString *urlParams = nil;


### PR DESCRIPTION
This filter disallows usage of non html extensions.

I'm using www assets hosted from a remote server which doesn't use .html extension.

This filter is restricting me from using extension-less urls.

This commit removes that restriction.